### PR TITLE
Add foreground service type to run with SDK 34

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
 		android:maxSdkVersion="28"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+		android:minSdkVersion="34" />
 	<application
 		tools:ignore="UnusedAttribute"
 		android:name=".app.ScreenTimeTrackerApp"
@@ -41,7 +43,8 @@
 		</receiver>
 		<service
 			android:name=".service.TrackerService"
-			android:exported="false"/>
+			android:exported="false"
+			android:foregroundServiceType="specialUse" />
 		<activity
 			android:name=".activity.MainActivity"
 			android:exported="true">

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/service/TrackerService.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/service/TrackerService.kt
@@ -6,6 +6,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
@@ -82,7 +83,11 @@ class TrackerService : Service() {
 		scope.launch {
 			val notification = buildAndScheduleNotification(now)
 			withContext(Dispatchers.Main) {
-				startForeground(NOTIFICATION_ID, notification)
+				if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+					startForeground(NOTIFICATION_ID, notification)
+				} else {
+					startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
SDK 34 requires foreground service to declare its type.

GPlay might require more explicit use case statement:
https://developer.android.com/about/versions/14/changes/fgs-types-required#special-use
but at least this commit builds and runs with SDK 34.