### PR TITLE
Visualization over multiple days

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,5 +53,6 @@
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
 		</activity>
+		<activity android:name=".activity.MultidayActivity"/>
 	</application>
 </manifest>

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/activity/MainActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/activity/MainActivity.kt
@@ -123,6 +123,7 @@ class MainActivity : Activity() {
 		menu?.let {
 			val visibility = progressView.visibility == View.GONE
 			arrayOf(
+				R.id.show_multiday,
 				R.id.disable_battery_optimization,
 				R.id.import_export_database
 			).forEach {
@@ -137,6 +138,10 @@ class MainActivity : Activity() {
 
 	override fun onOptionsItemSelected(item: MenuItem): Boolean {
 		return when (item.itemId) {
+			R.id.show_multiday -> {
+				startActivity(Intent(this, MultidayActivity::class.java))
+				true
+			}
 			R.id.disable_battery_optimization -> {
 				requestDisableBatteryOptimization()
 				true

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/activity/MultidayActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/activity/MultidayActivity.kt
@@ -1,0 +1,124 @@
+package de.markusfisch.android.screentime.activity
+
+import android.app.Activity
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.Typeface
+import android.os.Bundle
+import de.markusfisch.android.screentime.R
+import de.markusfisch.android.screentime.graphics.MultidayChart
+import de.markusfisch.android.screentime.graphics.loadColor
+import de.markusfisch.android.screentime.service.msToNextFullMinute
+import de.markusfisch.android.screentime.widget.BitmapView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class MultidayActivity : Activity() {
+	private val job = SupervisorJob()
+	private val scope = CoroutineScope(Dispatchers.Default + job)
+	private val usagePaint by lazy {
+		fillPaint(loadColor(R.color.usage)).apply {
+			xfermode = PorterDuffXfermode(PorterDuff.Mode.ADD)
+		}
+	}
+	private val usageDotPaint by lazy {
+		fillPaint(loadColor(R.color.usage_dot))
+	}
+	private val textPaint by lazy {
+		fillPaint(loadColor(R.color.text)).apply {
+			typeface = Typeface.DEFAULT_BOLD
+		}
+	}
+
+	private val days = 90
+
+	private lateinit var usageView: BitmapView
+
+	private var updateUsageRunnable: Runnable? = null
+	private var multidayChart: MultidayChart? = null
+	private var paused = true
+
+	override fun onCreate(state: Bundle?) {
+		super.onCreate(state)
+		setContentView(R.layout.multiday)
+		usageView = findViewById(R.id.graph)
+	}
+
+	override fun onResume() {
+		super.onResume()
+		// Post to run update() after layout.
+		postUsageUpdate(1)
+		paused = false
+	}
+
+	override fun onPause() {
+		super.onPause()
+		paused = true
+		cancelUsageUpdate()
+	}
+
+	override fun onDestroy() {
+		super.onDestroy()
+		job.cancelChildren()
+	}
+
+	private fun update(timestamp: Long = System.currentTimeMillis()) {
+		val width = usageView.measuredWidth
+		if (width < 1) {
+			postUsageUpdate()
+			return
+		}
+		val chart = getUsageChart(width) ?: return
+		scope.launch {
+			val bitmap = chart.draw(timestamp)
+			withContext(Dispatchers.Main) {
+				usageView.setBitmap(bitmap)
+				if (!paused) {
+					postUsageUpdate(msToNextFullMinute())
+				}
+			}
+		}
+	}
+
+	private fun getUsageChart(width: Int): MultidayChart? {
+		val dp = resources.displayMetrics.density
+		if (multidayChart == null || multidayChart?.width != width) {
+			multidayChart = MultidayChart(
+				width,
+				dp,
+				days,
+				usagePaint,
+				textPaint,
+				usageDotPaint,
+				loadColor(R.color.month_separator)
+			)
+		}
+		return multidayChart
+	}
+
+	private fun postUsageUpdate(delay: Long = 100L) {
+		cancelUsageUpdate()
+		updateUsageRunnable = Runnable {
+			update()
+		}
+		usageView.postDelayed(updateUsageRunnable, delay)
+	}
+
+	private fun cancelUsageUpdate() {
+		if (updateUsageRunnable != null) {
+			usageView.removeCallbacks(updateUsageRunnable)
+			updateUsageRunnable = null
+		}
+	}
+}
+
+private fun fillPaint(col: Int) = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+	color = col
+	style = Paint.Style.FILL
+}

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/graphics/MultidayChart.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/graphics/MultidayChart.kt
@@ -1,0 +1,177 @@
+package de.markusfisch.android.screentime.graphics
+
+import java.util.Calendar
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.Rect
+import de.markusfisch.android.screentime.app.db
+import de.markusfisch.android.screentime.app.prefs
+import de.markusfisch.android.screentime.database.DAY_IN_MS
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+class MultidayChart(
+	val width: Int,
+	private val dp: Float,
+	private val days: Int,
+	private val usagePaint: Paint,
+	private val textPaint: Paint,
+	private val usageDotPaint: Paint,
+	private val monthColor: Int
+) {
+	private val linePaint = Paint(textPaint).also { it.strokeWidth = 1f }
+	private val linePaintBold = Paint(linePaint).also { it.strokeWidth = 2f }
+	private val monthLinePaint = Paint(linePaintBold).also { it.strokeWidth = 4f; it.color = monthColor }
+
+	private val textBounds = Rect()
+
+	private val dayHeight = (24 * dp).roundToInt()
+	private val padding = (12 * dp).roundToInt()
+	private val offsetY = (32 * dp).roundToInt()
+
+	private val bitmapA = Bitmap.createBitmap(
+		width,
+		dayHeight * days + offsetY + padding,
+		Bitmap.Config.ARGB_8888
+	)
+	private val bitmapB = bitmapA.copy(bitmapA.config, true)
+
+	private var even = true
+
+	fun draw(timestamp: Long): Bitmap = nextBitmap().apply {
+		Canvas(this).apply {
+			drawColor(0, PorterDuff.Mode.CLEAR)
+			drawAt( timestamp )
+		}
+	}
+
+	private fun nextBitmap(): Bitmap {
+		// Double buffering to avoid modifying the
+		// currently displayed bitmap.
+		even = even xor true
+		return if (even) bitmapA else bitmapB
+	}
+
+	private fun Canvas.drawAt(timestamp: Long) {
+		val dayStart = prefs.dayStart(timestamp - DAY_IN_MS * (days - 1))
+		val dayEnd = prefs.dayStart(timestamp) + DAY_IN_MS
+
+		drawRecordsBetween(dayStart, dayEnd)
+
+		drawHours(prefs.hourOfDayChange)
+		drawDays(timestamp)
+	}
+
+	private fun Canvas.drawHours(hourOffset: Int) {
+		val width = this.width - padding * 2
+		val height = days * dayHeight
+
+		val hours = 24
+		for (i in 0..hours) {
+			val x = (i * width / hours + padding).toFloat()
+			val h = (i + hourOffset) % 24
+			val paint = when(h % 6 == 0) {
+				true -> linePaintBold
+				false -> linePaint
+			}
+			if (h % 3 == 0) {
+				drawTextCenteredAbove("$h", x, offsetY.toFloat())
+			}
+			drawLine(x, offsetY.toFloat(), x, (height + offsetY).toFloat(), paint)
+		}
+	}
+	private fun Canvas.drawDays(timestamp: Long) {
+		val sX = (padding).toFloat()
+		val eX = (width - padding).toFloat()
+
+		var midday = prefs.dayStart(timestamp) + DAY_IN_MS / 2 + DAY_IN_MS
+
+		val calendar = Calendar.getInstance()
+
+		for (d in 0..days) {
+			val y = d * dayHeight + offsetY
+			calendar.timeInMillis = midday
+
+			val paint = if (calendar.get(Calendar.DAY_OF_MONTH) == 1) {
+				monthLinePaint
+			} else if (calendar.get(Calendar.DAY_OF_WEEK) == calendar.firstDayOfWeek) {
+				linePaintBold
+			} else {
+				linePaint
+			}
+			drawLine(sX, y.toFloat(), eX, y.toFloat(), paint)
+			midday -= DAY_IN_MS
+		}
+	}
+
+	private fun Canvas.drawRecordsBetween(
+		from: Long, // day start
+		to: Long, // day start
+	) {
+		/* Every record is visualized/counted for minimum 1 minute duration.
+		   Not counting overlaps. */
+		val minimumDuration = 1L * 60L * 1000L
+
+		val width = this.width - padding * 2
+		val days = (to - from) / DAY_IN_MS
+
+		val dayUsage = LongArray(days.toInt()) {0}
+		val dayLastTimestamp = LongArray(days.toInt()) {0}
+
+		val drawInOneDay = { day: Long, start: Long, end: Long ->
+			val dayFromTop = (days - 1 - day).toInt()
+			val start = max(start, dayLastTimestamp[dayFromTop])
+			if (start <= end) {
+				dayUsage[dayFromTop] += end - start
+				dayLastTimestamp[dayFromTop] = end
+
+				val top = dayFromTop * dayHeight + offsetY
+				val bottom = (dayFromTop + 1) * dayHeight + offsetY
+				val left = (start * width / DAY_IN_MS + padding).toInt()
+				val right = (end * width / DAY_IN_MS + padding).toInt()
+				drawRect(Rect(left, top, right, bottom), usagePaint)
+			}
+		}
+		db.forEachRecordBetween(from, to) { start, duration ->
+			val end = start + max(duration, minimumDuration)
+			val dayS = (start - from) / DAY_IN_MS
+			val dayE = (end - from) / DAY_IN_MS
+
+			val s = start - from - dayS * DAY_IN_MS
+			val e = end - from - dayE * DAY_IN_MS
+
+			if (dayS == dayE) {
+				drawInOneDay(dayS, s, e)
+			} else {
+				drawInOneDay(dayS, s, DAY_IN_MS)
+				drawInOneDay(dayE, 0, e)
+			}
+		}
+
+		for (d in 0..<days.toInt()) {
+			drawCircle(
+				(padding + dayUsage[d] * width / DAY_IN_MS).toFloat(),
+				offsetY + dayHeight * (d + 0.5f),
+				dayHeight/6f,
+				usageDotPaint
+			)
+		}
+	}
+
+	private fun Canvas.drawTextCenteredAbove(
+		text: String,
+		x: Float,
+		y: Float
+	) {
+		textPaint.textSize = 12f * dp
+		textPaint.getTextBounds(text, 0, text.length, textBounds)
+		drawText(
+			text,
+			x - textBounds.centerX().toFloat(),
+			y - textBounds.height().toFloat(),
+			textPaint
+		)
+	}
+}

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/graphics/MultidayChart.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/graphics/MultidayChart.kt
@@ -121,9 +121,7 @@ class MultidayChart(
 		val dayUsage = LongArray(days) {0}
 		val dayLastTimestamp = LongArray(days) {0}
 
-		/* Every record is visualized/counted for minimum 1 minute duration.
-		   Not counting overlaps. */
-		val minimumDuration = 1L * 60L * 1000L
+		val minimumDurationLengthen = prefs.minDurationLengthenValue().toLong()
 
 		val width = this.width - padding * 2
 
@@ -155,7 +153,7 @@ class MultidayChart(
 			while (start > dayStarts[day + 1])
 				day++
 
-			val end = start + max(duration, minimumDuration)
+			val end = start + max(duration, minimumDurationLengthen)
 
 			var dayE = day
 			while (end > (dayStarts.getOrNull(dayE + 1) ?: end))

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/preference/Preferences.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/preference/Preferences.kt
@@ -25,12 +25,26 @@ class Preferences(context: Context) {
 			field = clamped
 		}
 
+	private val minDurationLengthenChoice = intArrayOf (
+		0, 1000, 5000, 10000, 15000, 20000, 30000, 40000,
+		50000, 60000, 80000, 100000, 120000, 150000, 3 * 60000, 4 * 60000,
+		5 * 60000, 6 * 60000, 7 * 60000, 8 * 60000, 9 * 60000, 10 * 60000, 12 * 60000, 15 * 60000,
+		20 * 60000, 30 * 60000, 40 * 60000, 50 * 60000, 60 * 60000
+	)
+	var minDurationLengthen = 0
+		set(value) {
+			apply(MIN_DURATION_LENGTHEN, value)
+			field = value
+		}
+	fun minDurationLengthenValue() = minDurationLengthenChoice.getOrNull(minDurationLengthen) ?: 0
+
 	init {
 		graphRange = preferences.getInt(GRAPH_RANGE, graphRange)
 		hourOfDayChange = preferences.getInt(
 			HOUR_OF_DAY_CHANGE,
 			hourOfDayChange
 		)
+		minDurationLengthen = preferences.getInt(MIN_DURATION_LENGTHEN, minDurationLengthen)
 	}
 
 	fun dayStart(timestamp: Long): Long = startOfDay(timestamp) { cal ->
@@ -47,5 +61,6 @@ class Preferences(context: Context) {
 	companion object {
 		private const val GRAPH_RANGE = "graph_range"
 		private const val HOUR_OF_DAY_CHANGE = "hour_of_day_change"
+		private const val MIN_DURATION_LENGTHEN = "min_duration_lengthen"
 	}
 }

--- a/app/src/main/kotlin/de/markusfisch/android/screentime/widget/BitmapView.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/screentime/widget/BitmapView.kt
@@ -1,0 +1,37 @@
+package de.markusfisch.android.screentime.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.View
+
+class BitmapView : View {
+	private val bitmapRect = Rect()
+
+	private var bitmap: Bitmap? = null
+
+	constructor(context: Context, attrs: AttributeSet, defStyle: Int) :
+			super(context, attrs, defStyle)
+
+	constructor(context: Context, attrs: AttributeSet) :
+			this(context, attrs, 0)
+
+	fun setBitmap(bitmap: Bitmap) {
+		if (layoutParams.height != bitmap.height) {
+			layoutParams = layoutParams.also { it.height = bitmap.height }
+		}
+		this.bitmap = bitmap
+		bitmapRect.set(0, 0, bitmap.width, bitmap.height)
+		invalidate()
+	}
+
+	override fun onDraw(canvas: Canvas) {
+		super.onDraw(canvas)
+		canvas.drawColor(0)
+		bitmap?.let {
+			canvas.drawBitmap(it, bitmapRect, bitmapRect, null)
+		}
+	}
+}

--- a/app/src/main/res/layout/multiday.xml
+++ b/app/src/main/res/layout/multiday.xml
@@ -1,4 +1,5 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/scroll"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:scrollbars="none"
@@ -7,9 +8,38 @@
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:orientation="vertical" >
+		<LinearLayout
+			android:id="@+id/prefix"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:paddingLeft="16dp"
+			android:paddingStart="16dp"
+			android:paddingRight="16dp"
+			android:paddingEnd="16dp"
+			android:paddingBottom="16dp"
+			android:paddingTop="16dp"
+			android:orientation="vertical" >
+			<TextView
+				android:layout_height="wrap_content"
+				android:layout_width="wrap_content"
+				android:textSize="16sp"
+				android:text="@string/explain_day_dot" />
+			<TextView
+				android:layout_height="wrap_content"
+				android:layout_width="wrap_content"
+				android:textSize="16sp"
+				android:text="@string/explain_horizontal_lines" />
+			<SeekBar
+				android:id="@+id/minDurationLengthenBar"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:paddingTop="16dp"
+				android:max="28"
+				android:progress="9"/>
+		</LinearLayout>
 		<de.markusfisch.android.screentime.widget.BitmapView
 			android:id="@+id/graph"
 			android:layout_width="match_parent"
-			android:layout_height="0dp" />
+			android:layout_height="2000000dp" />
 	</LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/multiday.xml
+++ b/app/src/main/res/layout/multiday.xml
@@ -1,0 +1,15 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:scrollbars="none"
+	android:fillViewport="true">
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical" >
+		<de.markusfisch.android.screentime.widget.BitmapView
+			android:id="@+id/graph"
+			android:layout_width="match_parent"
+			android:layout_height="0dp" />
+	</LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/activity_main.xml
+++ b/app/src/main/res/menu/activity_main.xml
@@ -1,5 +1,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 	<item
+		android:id="@+id/show_multiday"
+		android:title="@string/show_multiday"
+		android:icon="@android:drawable/ic_menu_recent_history"
+		android:showAsAction="ifRoom"/>
+	<item
 		android:id="@+id/disable_battery_optimization"
 		android:title="@string/disable_battery_optimization"
 		android:icon="@drawable/ic_action_battery"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,8 @@
 	<color name="window_background">#082a34</color>
 	<color name="dial">#0c4151</color>
 	<color name="usage">#1c9bbf</color>
+	<color name="usage_dot">#a7f192</color>
+	<color name="month_separator">#f49f45</color>
 	<color name="text">#fff</color>
 	<color name="background_progress">#8000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,6 @@
 	<string name="save_as">Save to Downloads as:</string>
 	<string name="enter_file_name">Enter a file name</string>
 	<string name="show_multiday">Show multiday</string>
+	<string name="explain_day_dot">Each line corresponds to a day. The dots correspond to the total time on a given day.</string>
+	<string name="explain_horizontal_lines">Bold horizontal lines correspond to a new week. Red horizontal lines correspond to a new month.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
 	<string name="export_failed">Export failed</string>
 	<string name="save_as">Save to Downloads as:</string>
 	<string name="enter_file_name">Enter a file name</string>
+	<string name="show_multiday">Show multiday</string>
 </resources>


### PR DESCRIPTION
_Hi, this PR is WIP. Mostly to gather feedback and to prevent duplicate work._

---

This PR adds another screen containing visualization of screen-time over multiple days.

I wanted to see not only the total time, but also the distribution itself.

Given the information density, I minimized the amount of text describing individual days, and I rather just highlighted starts of weeks/months.

Hopefully the visualization is mostly self explanatory. The green dots show total screen-time on given day, measured from left side.
I wanted to have the total time and distribution on the same screen, so that I can quickly compare them - with choice of colors so that my brain can easily choose which one to focus on.

Current limit is 90 days, which is probably the maximum that could be useful with this level of detail.
(For simplicity I create the whole graph as a single bitmap. Which for more days is no longer a good strategy)

---

Admittedly, it currently looks a bit ugly. Though I am not sure whether that ugliness is caused by the visualization method, or by my non-existent sleep schedule.. :D

![Screenshot_20240316-024740](https://github.com/markusfisch/ScreenTime/assets/75430933/faf5e1ea-97c2-4278-a3f6-3bb3bcac020c)